### PR TITLE
Make gmerge and gmap take more than one generators

### DIFF
--- a/chicken-test.scm
+++ b/chicken-test.scm
@@ -1,8 +1,11 @@
-(use test)
-(use srfi-158)
-(use (only srfi-1 unfold))
-(use srfi-4)
-(include "r7rs-shim.scm")
+(cond-expand
+ (gauche) ;; use gauche-test instead of directly load this file
+ (else
+  (use test)
+  (use srfi-158)
+  (use (only srfi-1 unfold))
+  (use srfi-4)
+  (include "r7rs-shim.scm")))
 
 (test-group "generators"
   (test-group "generators/constructors"
@@ -93,10 +96,40 @@
           (generator->list (ggroup (generator 1 2 3 4 5 6 7 8) 3)))
     (test '((1 2 3) (4 5 6) (7 8 0))
           (generator->list (ggroup (generator 1 2 3 4 5 6 7 8) 3 0)))
+    (test '(1 2 3)
+          (generator->list (gmerge < (generator 1 2 3))))
     (test '(1 2 3 4 5 6)
           (generator->list (gmerge < (generator 1 2 3) (generator 4 5 6))))
+    (test '(1 2 3 4 4 5 6)
+          (generator->list (gmerge <
+                                   (generator 1 2 4 6)
+                                   (generator)
+                                   (generator 3 4 5))))
+    (test '(1 2 3 4 5 6 7 8 9 10 11 12 13 14 15)
+          (generator->list (gmerge <
+                                   (generator 1 10 11)
+                                   (generator 2 9 12)
+                                   (generator 3 8 13)
+                                   (generator 4 7 14)
+                                   (generator 5 6 15))))
+    ;; check the tie-break rule
+    (test '((1 a) (1 e) (1 b) (1 c) (1 d))
+          (generator->list (gmerge (lambda (x y) (< (car x) (car y)))
+                                   (generator '(1 a) '(1 e))
+                                   (generator '(1 b))
+                                   (generator '(1 c) '(1 d)))))
+    
     (test '(-1 -2 -3 -4 -5)
           (generator->list (gmap - (generator 1 2 3 4 5))))
+    (test '(7 9 11 13)
+          (generator->list (gmap +
+                                 (generator 1 2 3 4 5)
+                                 (generator 6 7 8 9))))
+    (test '(54 140 264)
+          (generator->list (gmap *
+                                 (generator 1 2 3 4 5)
+                                 (generator 6 7 8)
+                                 (generator 9 10 11 12 13))))
     (test '(a c e g i)
           (generator->list
             (gstate-filter

--- a/gauche-test.scm
+++ b/gauche-test.scm
@@ -1,0 +1,20 @@
+;;
+;; Just load this file to test on Gauche:
+;;
+;;  $ gosh ./gauche-test
+;;
+
+(use gauche.test)
+(use compat.chibi-test)
+
+(add-load-path "." :relative)
+
+(test-start "srfi-158")
+(use srfi-158)
+(use scheme.base :only (string-for-each bytevector))
+(use scheme.list :only (unfold))
+(chibi-test (include "./chicken-test.scm"))
+
+(test-end)
+
+

--- a/srfi-158.html
+++ b/srfi-158.html
@@ -396,19 +396,28 @@ to length <i>k</i>.
 </dd></dl>
 
 <dl>
-<dt><code>gmerge</code><i> less-than genleft genright</i></dt>
+<dt><code>gmerge</code><i> less-than gen1 gen2 ...</i></dt>
 <dd><p>Returns a generator that yields the items from the given
 generators in the order dictated by <i>less-than</i>.
-If the items are equal, the left item is used first.
-When both given generators are exhausted, the returned generator
+If the items are equal, the leftmost item is used first.
+When all of given generators are exhausted, the returned generator
 is exhausted also.
+</p>
+<p>
+As a special case, if only one generator is given, it is returned.
 </p>
 </dd></dl>
 
 <dl>
-<dt><code>gmap</code><i> proc gen</i></dt>
-<dd><p>Returns a generator that yields the items from the given
+<dt><code>gmap</code><i> proc gen1 gen2 ...</i></dt>
+<dd><p>When only one generator is given,
+returns a generator that yields the items from the given
 generator after invoking <i>proc</i> on them.
+</p>
+<p>When more than one generator is given, each item of the resulting
+generator is a result of applying <i>proc</i> on the items from
+each generators.  If any of input generator is exhausted, the resulting
+generator is also exhausted.
 </p>
 <p>
 Note: This differs from <code>generator-map->list</code>,
@@ -419,8 +428,8 @@ while <code>gmap</code> returns a generator immediately without consuming input.
 <table><tbody><tr><td>&nbsp;</td><td><pre class="example">(generator-&gt;list (gmap - (make-range-generator 0 3)))
  ⇒ (0 -1 -2)
 
-(generator-&gt;list (gappend))
- ⇒ ()
+(generator-&gt;list (gmap cons (generator 1 2 3) (generator 4 5)))
+ ⇒ ((1 . 4) (2 . 5))
 </pre></td></tr></tbody></table>
 </dd></dl>
 


### PR DESCRIPTION
- Implementation and spec are changed.
- Tests for enhanced functionality are added.
- Test script for Gauche is added.
- The code of list->bytevector passed #f as the fill argument to make-bytevector, but it isn't allowed in R7RS, I think.  I changed it to 0.