### PR TITLE
Update reference implementation to remove gpath

### DIFF
--- a/chicken-test.scm
+++ b/chicken-test.scm
@@ -136,11 +136,6 @@
               (lambda (item state) (values (even? state) (+ 1 state)))
               0
               (generator 'a 'b 'c 'd 'e 'f 'g 'h 'i 'j))))
-    (test '("-1" "-2" "-3" "-4" "-5")
-               (generator->list
-                 (gpath (generator 1 2 3 4 5)
-                        (lambda (gen) (gmap - gen))
-                        (lambda (gen) (gmap number->string gen)))))
   ) ; end "generators/operators"
 
 

--- a/srfi-158-impl.scm
+++ b/srfi-158-impl.scm
@@ -415,12 +415,6 @@
           (truth value)
           (else (loop (value-gen) (truth-gen)))))))))
 
-;; gpath
-(define (gpath gen . components)
-  (if (null? components)
-    gen
-    (apply gpath ((car components) gen) (cdr components))))
-
 ;; generator->list
 (define generator->list
   (case-lambda ((gen n)

--- a/srfi-158.scm
+++ b/srfi-158.scm
@@ -14,7 +14,7 @@
   (export gcons* gappend gcombine gfilter gremove
           gtake gdrop gtake-while gdrop-while
           gflatten ggroup gmerge gmap gstate-filter
-          gdelete gdelete-neighbor-dups gindex gselect gpath)
+          gdelete gdelete-neighbor-dups gindex gselect)
   (export generator->list generator->reverse-list
           generator->vector generator->vector!  generator->string
           generator-fold generator-map->list generator-for-each generator-find


### PR DESCRIPTION
Gpath is removed from the final srfi document.  This patch adjust the reference implementation.