### PR TITLE
Fix generator-find to return #f when generator is exhausted

### DIFF
--- a/chicken-test.scm
+++ b/chicken-test.scm
@@ -157,6 +157,7 @@
       (generator-map->list (lambda values (apply + values))
         (generator 1 4) (generator 2 5) (generator 3 6)))
     (test 3 (generator-find (lambda (x) (> x 2)) (make-range-generator 1 5)))
+    (test #f (generator-find (lambda (x) (> x 10)) (make-range-generator 1 5)))
     (test 2 (generator-count odd? (make-range-generator 1 5)))
     (define g (make-range-generator 2 5))
     (test #t (generator-any odd? g))

--- a/srfi-158-impl.scm
+++ b/srfi-158-impl.scm
@@ -486,11 +486,9 @@
 ;; generator-find
 (define (generator-find pred g)
   (let loop ((v (g)))
-   ; A literal interpretation might say it only terminates on #eof if (pred #eof) but I think this makes more sense...
-   (if (or (pred v) (eof-object? v))
-     v
-     (loop (g)))))
-
+    (cond ((eof-object? v) #f)
+          ((pred v) v)
+          (else (loop (g))))))
 
 ;; generator-count
 (define (generator-count pred g)


### PR DESCRIPTION
This fixes a bug pointed out in https://srfi-email.schemers.org/srfi-158/msg/15082053/

Actually, I don't quite understand the comment in the original code.  I replaced the body with Gauche's implementation.

