### PR TITLE
Fix generator-any and generator-every

### DIFF
--- a/chicken-test.scm
+++ b/chicken-test.scm
@@ -163,8 +163,13 @@
     (test #t (generator-any odd? g))
     (test '(4) (generator->list g))
     (define g (make-range-generator 2 5))
+    (test 3 (generator-any (lambda (x) (and (odd? x) x)) g))
+    (define g (make-range-generator 2 5))
     (test #f (generator-every odd? g))
     (test '(3 4) (generator->list g))
+    (define g (make-range-generator 2 5))
+    (test 4 (generator-every (lambda (x) (and (> x 1) x)) g))
+    (test '() (generator->list g))
     (test '(#\a #\b #\c) (generator-unfold (make-for-each-generator string-for-each "abc") unfold))
 
   ) ; end "generators/consumers"

--- a/srfi-158-impl.scm
+++ b/srfi-158-impl.scm
@@ -496,24 +496,22 @@
 
 
 ;; generator-any
-(define (generator-any pred g)
-  (let loop ((v (g)))
-   (if (eof-object? v)
-     #f
-     (if (pred v)
-       #t
-       (loop (g))))))
+(define (generator-any pred gen)
+  (let loop ((item (gen)))
+    (cond ((eof-object? item) #f)
+          ((pred item))
+          (else (loop (gen))))))
 
 
 ;; generator-every
-(define (generator-every pred g)
-  (let loop ((v (g)))
-   (if (eof-object? v)
-     #t
-     (if (pred v)
-       (loop (g))
-       #f ; the spec would have me return #f, but I think it must simply be wrong...
-       ))))
+(define (generator-every pred gen)
+  (let loop ((item (gen)) (last #t))
+    (if (eof-object? item)
+      last
+      (let ((r (pred item)))
+        (if r
+          (loop (gen) r)
+          #f)))))
 
 
 ;; generator-unfold


### PR DESCRIPTION
The same issues as https://github.com/scheme-requests-for-implementation/srfi-121/commit/9abfd947fbc74703a7f35ab523a03da488d23a42
It looks like generator-find was fixed, but *-any and *-every were overlooked.